### PR TITLE
feat: add gym level field to route mission

### DIFF
--- a/src/main/java/com/climbup/climbup/recommendation/dto/response/RouteMissionRecommendationResponse.java
+++ b/src/main/java/com/climbup/climbup/recommendation/dto/response/RouteMissionRecommendationResponse.java
@@ -3,6 +3,7 @@ package com.climbup.climbup.recommendation.dto.response;
 import com.climbup.climbup.attempt.dto.response.UserMissionAttemptResponse;
 import com.climbup.climbup.attempt.entity.UserMissionAttempt;
 import com.climbup.climbup.gym.entity.ClimbingGym;
+import com.climbup.climbup.gym.dto.response.GymLevelResponse;
 import com.climbup.climbup.recommendation.entity.ChallengeRecommendation;
 import com.climbup.climbup.route.entity.RouteMission;
 import com.climbup.climbup.sector.dto.SectorResponse;
@@ -30,6 +31,9 @@ public class RouteMissionRecommendationResponse {
 
     @Schema(description = "섹터 데이터")
     private SectorResponse sector;
+
+    @Schema(description = "암장 난이도")
+    private GymLevelResponse gymLevel;
 
     @Schema(description = "루트미션 난이도", example = "BLUE")
     private String difficulty;
@@ -59,6 +63,7 @@ public class RouteMissionRecommendationResponse {
                 .attempts(attempts.stream().map(UserMissionAttemptResponse::toDto).toList())
                 .sector(SectorResponse.toDto(sector))
                 .difficulty(recommendation.getDifficulty())
+                .gymLevel(GymLevelResponse.fromEntity(mission.getGymLevel()))
                 .score(mission.getScore())
                 .imageUrl(mission.getImageUrl())
                 .videoUrl(mission.getVideoUrl())

--- a/src/main/java/com/climbup/climbup/route/dto/response/RouteMissionListResponse.java
+++ b/src/main/java/com/climbup/climbup/route/dto/response/RouteMissionListResponse.java
@@ -1,5 +1,6 @@
 package com.climbup.climbup.route.dto.response;
 
+import com.climbup.climbup.gym.dto.response.GymLevelResponse;
 import com.climbup.climbup.route.entity.RouteMission;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,6 +26,9 @@ public class RouteMissionListResponse {
     @Schema(description = "난이도", example = "BLUE")
     private String difficulty;
 
+    @Schema(description = "암장 난이도")
+    private GymLevelResponse gymLevel;
+
     @Schema(description = "점수", example = "100")
     private Integer score;
 
@@ -44,6 +48,7 @@ public class RouteMissionListResponse {
                 .gymName(mission.getGym().getName())
                 .sectorName(mission.getSector().getName())
                 .difficulty(mission.getDifficulty())
+                .gymLevel(GymLevelResponse.fromEntity(mission.getGymLevel()))
                 .score(mission.getScore())
                 .imageUrl(mission.getImageUrl())
                 .thumbnailUrl(mission.getThumbnailUrl())

--- a/src/main/java/com/climbup/climbup/route/entity/RouteMission.java
+++ b/src/main/java/com/climbup/climbup/route/entity/RouteMission.java
@@ -3,13 +3,13 @@ package com.climbup.climbup.route.entity;
 import com.climbup.climbup.attempt.entity.UserMissionAttempt;
 import com.climbup.climbup.common.entity.BaseEntity;
 import com.climbup.climbup.gym.entity.ClimbingGym;
+import com.climbup.climbup.gym.entity.GymLevel;
 import com.climbup.climbup.recommendation.entity.ChallengeRecommendation;
 import com.climbup.climbup.sector.entity.Sector;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +39,10 @@ public class RouteMission extends BaseEntity {
 
     @Column(name = "score", nullable = false)
     private Integer score;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "gym_level_id", nullable = false)
+    private GymLevel gymLevel;
 
     @Column(name = "image_url", nullable = false, columnDefinition = "TEXT")
     private String imageUrl;


### PR DESCRIPTION
## 📌 PR 제목
- feat: add gym level field to route mission

## 📋 작업 내용
- 루트 미션에 암장 레벨 필드까지 추가해서 전달

## ✅ 체크리스트
- [x] 테스트를 완료했나요?
- [x] 코드 컨벤션을 지켰나요?
- [ ] 관련 문서를 업데이트 했나요?

## 🚨 주의사항
- 리뷰어가 주의깊게 봐야할 부분이 있다면 적어주세요.
